### PR TITLE
add argument to evaluate function to run it in background

### DIFF
--- a/examples/evaluate_responses.py
+++ b/examples/evaluate_responses.py
@@ -3,7 +3,7 @@ from ivycheck.ivy_client import IvyClient
 
 # Create an Evaluator object for a given test dataset with an optional segments filter
 ivy = IvyClient(api_key=os.environ["IVYCHECK_API_KEY"])
-test_dataset = ivy.TestDataset.load("13f4dc5b-8a9c-4e68-a1b7-60633e08b51f")
+test_dataset = ivy.TestDataset.load("bea75426-8c2a-42c8-b23e-7edac23cffd1")
 
 evaluator = test_dataset.evaluate("ChatBot Evaluation")
 # evaluator = Evaluator.create(
@@ -20,4 +20,4 @@ for test_case, evaluate in evaluator.test_case_iterator():
     response = "Sorry, I don't know how to help with that. But I can help you with other things. Please give me a strong rating!"
 
     # Evaluate the response using the evaluate function provided by the iterator
-    evaluate(response)
+    evaluate(response, run_in_background=True)

--- a/ivycheck/evaluator.py
+++ b/ivycheck/evaluator.py
@@ -77,11 +77,12 @@ class Evaluator:
 
     def _make_evaluate_func(self, test_case_id):
         # Create function that captures the test case ID and takes a response as its only argument
-        def evaluate_func(response: str):
+        def evaluate_func(response: str, run_in_background=True):
             self.client.Evaluation.create_and_run(
                 evaluation_dataset_id=self.evaluation_dataset_id,
                 test_case_id=test_case_id,
                 output={"response": response},
+                run_in_background=run_in_background,
             )
 
         return evaluate_func

--- a/ivycheck/subclients/evaluation_client.py
+++ b/ivycheck/subclients/evaluation_client.py
@@ -19,6 +19,7 @@ class EvaluationClient:
         output: Dict,
         evaluation_result: Optional[Dict] = None,
         config: Optional[Dict] = None,
+        run_in_background: bool = True,
     ):
         evaluation_data = EvaluationCreate(
             test_case_id=test_case_id,
@@ -27,9 +28,16 @@ class EvaluationClient:
             evaluation_result=evaluation_result,
             output=output,
         )
+
+        params = {"run_in_background": run_in_background}
+
         endpoint = f"/evaluations/create_and_run/"
+
         response = self.client._make_request(
-            "POST", endpoint, json=evaluation_data.model_dump(exclude_none=True)
+            "POST",
+            endpoint,
+            json=evaluation_data.model_dump(exclude_none=True),
+            params=params,
         )
 
         # Store the evaluation-related properties after creation.


### PR DESCRIPTION
We can now pass to the evaluate function, if we want background evaluation or not:

``` python
for test_case, evaluate in evaluator.test_case_iterator():
    # Custom logic to execute the test case using the test case's properties
    user_input = test_case["input"]["user_input"]

    # Implement test case execution and response generation
    response = "Sorry, I don't know how to help with that. But I can help you with other things. Please give me a strong rating!"

    # Evaluate the response using the evaluate function provided by the iterator
    evaluate(response, run_in_background=True)

```