### PR TITLE
Retrieve Evaluation ULR

### DIFF
--- a/examples/evaluate_responses.py
+++ b/examples/evaluate_responses.py
@@ -11,7 +11,6 @@ evaluator = test_dataset.evaluate("ChatBot Evaluation")
 #     test_dataset_id=test_dataset.id,
 #     evaluator_description="ChatBot Evaluation 1",
 # )
-print(evaluator.eval_url)
 
 for test_case, evaluate in evaluator.test_case_iterator():
     # Custom logic to execute the test case using the test case's properties

--- a/examples/evaluate_responses.py
+++ b/examples/evaluate_responses.py
@@ -3,7 +3,7 @@ from ivycheck.ivy_client import IvyClient
 
 # Create an Evaluator object for a given test dataset with an optional segments filter
 ivy = IvyClient(api_key=os.environ["IVYCHECK_API_KEY"])
-test_dataset = ivy.TestDataset.load("13f4dc5b-8a9c-4e68-a1b7-60633e08b51f")
+test_dataset = ivy.TestDataset.load("bea75426-8c2a-42c8-b23e-7edac23cffd1")
 
 evaluator = test_dataset.evaluate("ChatBot Evaluation")
 # evaluator = Evaluator.create(
@@ -11,6 +11,7 @@ evaluator = test_dataset.evaluate("ChatBot Evaluation")
 #     test_dataset_id=test_dataset.id,
 #     evaluator_description="ChatBot Evaluation 1",
 # )
+print(evaluator.eval_url)
 
 for test_case, evaluate in evaluator.test_case_iterator():
     # Custom logic to execute the test case using the test case's properties

--- a/ivycheck/evaluator.py
+++ b/ivycheck/evaluator.py
@@ -36,6 +36,22 @@ class Evaluator:
     ):
         return cls(client, test_dataset_id, segments, evaluator_description)
 
+    @property
+    def eval_url_from_endpoint(self):
+        if self.evaluation_dataset_id is None:
+            raise ValueError("Evaluation Dataset ID has not been set.")
+        else:
+            return self.client._make_request(
+                "GET", f"/evaluation_datasets/url/{self.evaluation_dataset_id}"
+            )
+
+    @property
+    def eval_url(self):
+        if self.evaluation_dataset_id is None:
+            raise ValueError("Evaluation Dataset ID has not been set.")
+        else:
+            return f"https://app.ivycheck.com/projects/{self.client.TestDataset.project_id}/evals/{self.evaluation_dataset_id}"
+
     def _prepare_evaluation_dataset(self):
         # Reads the test dataset and creates the evaluation dataset
         test_dataset = self.client.TestDataset._read(

--- a/ivycheck/evaluator.py
+++ b/ivycheck/evaluator.py
@@ -40,7 +40,7 @@ class Evaluator:
         return cls(client, test_dataset_id, segments, evaluator_description)
 
     @property
-    def eval_url_from_endpoint(self):
+    def eval_url(self):
         if self.evaluation_dataset_id is None:
             raise ValueError("Evaluation Dataset ID has not been set.")
         else:
@@ -48,12 +48,13 @@ class Evaluator:
                 "GET", f"/evaluation_datasets/url/{self.evaluation_dataset_id}"
             )
 
-    @property
-    def eval_url(self):
-        if self.evaluation_dataset_id is None:
-            raise ValueError("Evaluation Dataset ID has not been set.")
-        else:
-            return f"https://app.ivycheck.com/projects/{self.client.TestDataset.project_id}/evals/{self.evaluation_dataset_id}"
+    # construct URL from project ID and evaluation dataset ID intead of calling endpoing
+    # @property
+    # def eval_url(self):
+    #     if self.evaluation_dataset_id is None:
+    #         raise ValueError("Evaluation Dataset ID has not been set.")
+    #     else:
+    #         return f"https://app.ivycheck.com/projects/{self.client.TestDataset.project_id}/evals/{self.evaluation_dataset_id}"
 
     def _prepare_evaluation_dataset(self):
         # Reads the test dataset and creates the evaluation dataset

--- a/ivycheck/evaluator.py
+++ b/ivycheck/evaluator.py
@@ -26,6 +26,9 @@ class Evaluator:
         )
         self._prepare_evaluation_dataset()
 
+        if self.client.print_output:
+            print(f"Evaluation URL: {self.eval_url}")
+
     @classmethod
     def create(
         cls,

--- a/ivycheck/ivy_client.py
+++ b/ivycheck/ivy_client.py
@@ -9,8 +9,9 @@ from ivycheck.helperfunctions import APIRequestError
 
 # https://ivycheck-backend.onrender.com/
 class IvyClient:
-    def __init__(self, api_key=None, base_url=None) -> None:
+    def __init__(self, api_key=None, base_url=None, print_output=True) -> None:
         self.base_url = base_url
+        self.print_output = print_output
 
         if api_key is None:
             api_key = os.getenv("IVYCHECK_API_KEY")

--- a/ivycheck/subclients/test_dataset_client.py
+++ b/ivycheck/subclients/test_dataset_client.py
@@ -40,6 +40,7 @@ class TestDatasetClient:
             "POST", "/test_case_datasets/", json=validated_data
         )
 
+        self.project_id = project_id
         self.id = response["id"]
         self.name = response.get("name")
         self.description = response.get("description")
@@ -60,6 +61,7 @@ class TestDatasetClient:
             segments=segments,
             evaluator_description=evaluator_description,
         )
+
         return evaluator
 
     def add_test_case(
@@ -150,6 +152,7 @@ class TestDatasetClient:
         self.name = data.get("name")
         self.description = data.get("description")
         self.test_config = data.get("test_config")
+        self.project_id = data.get("prompt_id")
 
         # Return the TestDatasetClient instance for method chaining
         return self


### PR DESCRIPTION
We can use the new backend endpoint to retrieve the URL but also construct it in the frontend where the IDs are available. This implements both

Currently, you need to call the property `evaluator.eval_url`. We could also return it or print it. Thoughts?